### PR TITLE
auth middleware and routing

### DIFF
--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -1,1 +1,23 @@
 package auth
+
+import (
+	"fmt"
+	"github.com/wiryawan46/go-grpc-api-gateway/pkg/auth/pb"
+	"github.com/wiryawan46/go-grpc-api-gateway/pkg/config"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type ServiceClient struct {
+	Client pb.AuthServiceClient
+}
+
+func InitServiceClient(c *config.Config) pb.AuthServiceClient {
+	// using WithInsecure() because no SSL running
+	cc, err := grpc.Dial(c.AuthSvcUrl, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	if err != nil {
+		fmt.Println("Could not connect:", err)
+	}
+	return pb.NewAuthServiceClient(cc)
+}

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -1,1 +1,45 @@
 package auth
+
+import (
+	"context"
+	"github.com/gin-gonic/gin"
+	"github.com/wiryawan46/go-grpc-api-gateway/pkg/auth/pb"
+	"net/http"
+	"strings"
+)
+
+type AuthMiddlewareConfig struct {
+	svc *ServiceClient
+}
+
+func InitAuthMiddleware(svc *ServiceClient) AuthMiddlewareConfig {
+	return AuthMiddlewareConfig{svc}
+}
+
+func (c *AuthMiddlewareConfig) AuthRequired(ctx *gin.Context) {
+	authorization := ctx.Request.Header.Get("Authorization")
+
+	if authorization == "" {
+		ctx.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
+
+	token := strings.Split(authorization, "Bearer ")
+
+	if len(token) < 2 {
+		ctx.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
+
+	res, err := c.svc.Client.Validate(context.Background(), &pb.ValidateRequest{
+		Token: token[1],
+	})
+
+	if err != nil || res.Status != http.StatusOK {
+		ctx.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
+	ctx.Set("userId", res.UserId)
+
+	ctx.Next()
+}

--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -1,1 +1,27 @@
 package auth
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/wiryawan46/go-grpc-api-gateway/pkg/auth/routes"
+	"github.com/wiryawan46/go-grpc-api-gateway/pkg/config"
+)
+
+func RegisterRoutes(r *gin.Engine, c *config.Config) *ServiceClient {
+	svc := &ServiceClient{
+		Client: InitServiceClient(c),
+	}
+
+	routes := r.Group("/auth")
+	routes.POST("/register", svc.Register)
+	routes.POST("/login", svc.Login)
+
+	return svc
+}
+
+func (i *ServiceClient) Register(ctx *gin.Context) {
+	routes.Register(ctx, i.Client)
+}
+
+func (i *ServiceClient) Login(ctx *gin.Context) {
+	routes.Login(ctx, i.Client)
+}


### PR DESCRIPTION
**Background**
We need to protect the Product and Order Microservice from unauthorized requests. That means, on some routes, we only allow logged-in users to address our protected microservices.

So what we do here is simpler than its might look. We get the JSON Web Token from the HTTP request header, and then, we `validate` this token by the authentication microservice. Remember, we defined a validate endpoint in the `auth.proto` file earlier.

If the token is validated, we will let the request pass. If not, we will throw an unauthorized HTTP error.